### PR TITLE
Delete global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,0 @@
-{
-    "sdk": {
-        "version": "8.0.412",
-        "rollForward": "latestMinor"
-    },
-    "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "3.0.44"
-    }
-}


### PR DESCRIPTION
This pull request removes the `global.json` file, which previously specified the .NET SDK version and MSBuild SDKs. This change eliminates the explicit SDK version and configuration, potentially allowing the project to use the default SDK settings or rely on other configuration mechanisms.