### PR TITLE
feat: expand framework support and update dependencies

### DIFF
--- a/.github/workflows/BuildOnly.yml
+++ b/.github/workflows/BuildOnly.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,6 +43,17 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerMinimumMajorMinor>1.1</MinVerMinimumMajorMinor>
+    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
@@ -58,11 +69,4 @@
     <PackageReference Include="StyleSharp.Analyzers" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" PrivateAssets="All" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
-    <MinVerMinimumMajorMinor>1.1</MinVerMinimumMajorMinor>
-    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
-    <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
-  </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,17 +9,17 @@
     <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
-    <PackageVersion Include="ReactiveUI.Primitives" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Wpf.Reactive" Version="6.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives" Version="7.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="7.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.Wpf.Reactive" Version="7.0.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="StyleSharp.Analyzers" Version="3.28.1" />
+    <PackageVersion Include="StyleSharp.Analyzers" Version="3.38.1" />
     <PackageVersion Include="System.Management" Version="10.0.10" />
     <PackageVersion Include="System.Resources.Extensions" Version="10.0.10" />
-    <PackageVersion Include="TUnit" Version="1.61.15" />
+    <PackageVersion Include="TUnit" Version="1.61.23" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
     <PackageVersion Include="CP.Nuke.BuildTools" Version="3.0.2" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/Localisation.Avalonia.Tests/AvaloniaLocalizationTests.cs
+++ b/src/Localisation.Avalonia.Tests/AvaloniaLocalizationTests.cs
@@ -51,7 +51,7 @@ internal sealed class AvaloniaLocalizationTests
     private const string TestResxName = "Localisation.Avalonia.Tests.TestResources";
 
     [Test]
-    public async Task CultureManagersPublishAndSynchronizeChanges()
+    internal async Task CultureManagersPublishAndSynchronizeChanges()
     {
         var originalLeanCulture = Lean.CultureManager.UICulture;
         var originalLeanSynchronization = Lean.CultureManager.SynchronizeThreadCulture;
@@ -105,7 +105,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task ResourceExtensionsResolveEmbeddedOverridesDefaultsAndFormatting()
+    internal async Task ResourceExtensionsResolveEmbeddedOverridesDefaultsAndFormatting()
     {
         var target = new TextBlock();
         Lean.ResxExtension.SetDefaultResxName(target, TestResxName);
@@ -152,7 +152,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task RefreshingObservablesRespectKeysAndDisposeSubscriptions()
+    internal async Task RefreshingObservablesRespectKeysAndDisposeSubscriptions()
     {
         var leanValue = 0;
         var reactiveValue = 0;
@@ -184,7 +184,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task MarkupExtensionsCreateAvaloniaBindings()
+    internal async Task MarkupExtensionsCreateAvaloniaBindings()
     {
         var leanTarget = new TextBlock();
         var reactiveTarget = new TextBlock();
@@ -212,7 +212,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task EnumConvertersLocalizeSimpleAndFlagValues()
+    internal async Task EnumConvertersLocalizeSimpleAndFlagValues()
     {
         var manager = new ResourceManager(TestResxName, typeof(AvaloniaLocalizationTests).Assembly);
         var leanSimple = new Lean.ResourceEnumConverter(typeof(SampleValue), manager);
@@ -273,7 +273,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task ConverterGuardsCoverDefensivePaths()
+    internal async Task ConverterGuardsCoverDefensivePaths()
     {
         var originalCulture = CultureInfo.CurrentCulture;
         var originalUiCulture = CultureInfo.CurrentUICulture;
@@ -334,7 +334,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task ExtensionHelpersAndConverterFallbacksResolveValues()
+    internal async Task ExtensionHelpersAndConverterFallbacksResolveValues()
     {
         var manager = new ResourceManager(TestResxName, typeof(AvaloniaLocalizationTests).Assembly);
         var leanSimple = new Lean.ResourceEnumConverter(typeof(SampleValue), manager);
@@ -361,7 +361,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task AdditionalResxPathsHandleMissingResourcesAndClrProperties()
+    internal async Task AdditionalResxPathsHandleMissingResourcesAndClrProperties()
     {
         var lean = new Lean.ResxExtension
         {
@@ -404,7 +404,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task HeadlessAvaloniaSessionCreatesControls()
+    internal async Task HeadlessAvaloniaSessionCreatesControls()
     {
         await using var session = HeadlessUnitTestSession.StartNew(typeof(TestApplication));
         var text = await session.Dispatch(
@@ -414,7 +414,7 @@ internal sealed class AvaloniaLocalizationTests
     }
 
     [Test]
-    public async Task ValidationGuardsRejectInvalidArguments()
+    internal async Task ValidationGuardsRejectInvalidArguments()
     {
         var nullAttachedTargetRejected = false;
         var whitespaceKeyRejected = false;
@@ -455,13 +455,13 @@ internal sealed class AvaloniaLocalizationTests
     {
         if (!CultureMatches(current, FrenchCultureName) && !CultureMatches(excluded, FrenchCultureName))
         {
-            return new CultureInfo(FrenchCultureName);
+            return new(FrenchCultureName);
         }
 
         var cultureName = !CultureMatches(current, EnglishCultureName) && !CultureMatches(excluded, EnglishCultureName)
             ? EnglishCultureName
             : GermanCultureName;
-        return new CultureInfo(cultureName);
+        return new(cultureName);
     }
 
     private static bool CultureMatches(CultureInfo? culture, string name) =>

--- a/src/Localisation.Avalonia.Tests/TestApplication.cs
+++ b/src/Localisation.Avalonia.Tests/TestApplication.cs
@@ -8,9 +8,9 @@ namespace Localisation.Avalonia.Tests;
 
 internal sealed class TestApplication : Application
 {
-    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<TestApplication>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
-
     public override void Initialize()
     {
     }
+
+    internal static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<TestApplication>().UseHeadless(new());
 }

--- a/src/Localisation.Avalonia/Localisation/ResourceEnumConverter.cs
+++ b/src/Localisation.Avalonia/Localisation/ResourceEnumConverter.cs
@@ -63,7 +63,7 @@ public class ResourceEnumConverter : EnumConverter, IValueConverter
         var result = new List<KeyValuePair<Enum, string?>>();
         foreach (Enum value in Enum.GetValues(enumType))
         {
-            result.Add(new KeyValuePair<Enum, string?>(value, converter.ConvertToString(null, culture, value)));
+            result.Add(new(value, converter.ConvertToString(null, culture, value)));
         }
 
         return result;

--- a/src/Localisation.Avalonia/Localisation/ResourceRefreshEventArgs.cs
+++ b/src/Localisation.Avalonia/Localisation/ResourceRefreshEventArgs.cs
@@ -14,5 +14,5 @@ namespace CP.Localisation.Avalonia;
 internal sealed class ResourceRefreshEventArgs(string? key) : EventArgs
 {
     /// <summary>Gets the resource key, or <see langword="null"/> for every key.</summary>
-    public string? Key { get; } = key;
+    internal string? Key { get; } = key;
 }

--- a/src/Localisation.Avalonia/Localisation/ResxExtension.cs
+++ b/src/Localisation.Avalonia/Localisation/ResxExtension.cs
@@ -159,7 +159,7 @@ public sealed class ResxExtension
             }
 
             _ = _resourceManagers.Remove(resxName);
-            var resourceName = resxName + ".resources";
+            var resourceName = $"{resxName}.resources";
             var assembly = AppDomain.CurrentDomain.GetAssemblies()
                 .Where(static candidate => !candidate.IsDynamic)
                 .FirstOrDefault(candidate => candidate.GetManifestResourceNames().Contains(resourceName, StringComparer.Ordinal));
@@ -169,7 +169,7 @@ public sealed class ResxExtension
             }
 
             var manager = new ResourceManager(resxName, assembly);
-            _resourceManagers.Add(resxName, new WeakReference<ResourceManager>(manager));
+            _resourceManagers.Add(resxName, new(manager));
             return manager;
         }
     }

--- a/src/Localisation.WPF.Reactive/Localisation.WPF.Reactive.csproj
+++ b/src/Localisation.WPF.Reactive/Localisation.WPF.Reactive.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Management" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Resources.Extensions" />
   </ItemGroup>
 

--- a/src/Localisation.WPF.TestApp/Localisation.WPF.TestApp.csproj
+++ b/src/Localisation.WPF.TestApp/Localisation.WPF.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>

--- a/src/Localisation.WPF.Tests/WpfLocalizationTests.cs
+++ b/src/Localisation.WPF.Tests/WpfLocalizationTests.cs
@@ -47,7 +47,7 @@ internal sealed class WpfLocalizationTests
     private const string UpdatedValue = "Updated";
 
     [Test]
-    public async Task CultureManagersPublishAndSynchronizeChanges()
+    internal async Task CultureManagersPublishAndSynchronizeChanges()
     {
         var originalLeanCulture = Lean.CultureManager.UICulture;
         var originalLeanSynchronization = Lean.CultureManager.SynchronizeThreadCulture;
@@ -101,7 +101,7 @@ internal sealed class WpfLocalizationTests
     }
 
     [Test]
-    public async Task ExtensionMethodsSynchronizeCulturesAndConvertEnums()
+    internal async Task ExtensionMethodsSynchronizeCulturesAndConvertEnums()
     {
         var originalCulture = CultureInfo.CurrentCulture;
         var originalUiCulture = CultureInfo.CurrentUICulture;
@@ -124,7 +124,7 @@ internal sealed class WpfLocalizationTests
     }
 
     [Test]
-    public async Task ResourceEventArgumentsExposeValuesAndValidateCulture()
+    internal async Task ResourceEventArgumentsExposeValuesAndValidateCulture()
     {
         var lean = new Lean.GetResourceEventArgs(TestResxName, GreetingKey, CultureInfo.InvariantCulture)
         {
@@ -152,7 +152,7 @@ internal sealed class WpfLocalizationTests
     }
 
     [Test]
-    public async Task EnumConvertersLocalizeSimpleAndFlagValues()
+    internal async Task EnumConvertersLocalizeSimpleAndFlagValues()
     {
         var manager = new ResourceManager(TestResxName, typeof(WpfLocalizationTests).Assembly);
         var leanSimple = new Lean.ResourceEnumConverter(typeof(SampleValue), manager);
@@ -184,7 +184,7 @@ internal sealed class WpfLocalizationTests
     }
 
     [Test]
-    public async Task ManagedExtensionsRegisterAndUpdateDependencyAndClrTargets()
+    internal async Task ManagedExtensionsRegisterAndUpdateDependencyAndClrTargets()
     {
         var result = RunOnSta(
             static () =>
@@ -240,7 +240,7 @@ internal sealed class WpfLocalizationTests
     }
 
     [Test]
-    public async Task ResxAndUiCultureExtensionsUpdateRegisteredTargets()
+    internal async Task ResxAndUiCultureExtensionsUpdateRegisteredTargets()
     {
         var result = RunOnSta(
             static () =>
@@ -292,7 +292,7 @@ internal sealed class WpfLocalizationTests
     }
 
     [Test]
-    public async Task ReactiveManagedExtensionsRegisterAndUpdateTargets()
+    internal async Task ReactiveManagedExtensionsRegisterAndUpdateTargets()
     {
         var result = RunOnSta(
             static () =>
@@ -322,7 +322,7 @@ internal sealed class WpfLocalizationTests
     }
 
     [Test]
-    public async Task ResxBindingPropertyWrappersRoundTripForBothVariants()
+    internal async Task ResxBindingPropertyWrappersRoundTripForBothVariants()
     {
         var result = RunOnSta(
             static () => ValidateLeanBindingProperties() && ValidateReactiveBindingProperties());
@@ -337,13 +337,13 @@ internal sealed class WpfLocalizationTests
     {
         if (!CultureMatches(current, FrenchCultureName) && !CultureMatches(excluded, FrenchCultureName))
         {
-            return new CultureInfo(FrenchCultureName);
+            return new(FrenchCultureName);
         }
 
         var cultureName = !CultureMatches(current, EnglishCultureName) && !CultureMatches(excluded, EnglishCultureName)
             ? EnglishCultureName
             : GermanCultureName;
-        return new CultureInfo(cultureName);
+        return new(cultureName);
     }
 
     private static T RunOnSta<T>(Func<T> action)
@@ -404,7 +404,7 @@ internal sealed class WpfLocalizationTests
         extension.BindingValidatesOnExceptions = true;
         extension.BindingXPath = BindingXPath;
         extension.BindsDirectlyToSource = true;
-        extension.Children.Add(new Lean.ResxExtension("Child"));
+        extension.Children.Add(new("Child"));
 
         _ = extension.BindingAsyncState;
         _ = extension.BindingConverter;
@@ -464,7 +464,7 @@ internal sealed class WpfLocalizationTests
         extension.BindingValidatesOnExceptions = true;
         extension.BindingXPath = BindingXPath;
         extension.BindsDirectlyToSource = true;
-        extension.Children.Add(new Reactive.ResxExtension("Child"));
+        extension.Children.Add(new("Child"));
 
         _ = extension.BindingAsyncState;
         _ = extension.BindingConverter;

--- a/src/Localisation.WPF/Localisation.WPF.csproj
+++ b/src/Localisation.WPF/Localisation.WPF.csproj
@@ -1,16 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>CP.Localisation</RootNamespace>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <NeutralLanguage>en-US</NeutralLanguage>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
-    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Management" />
@@ -22,7 +19,7 @@
     <Using Include="ReactiveUI.Primitives.RxVoid" Alias="RxVoid" />
     <Using Include="ReactiveUI.Primitives.Signals" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Resources.Extensions" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Localisation.WPF/Localisation/ManagedMarkupExtension.cs
+++ b/src/Localisation.WPF/Localisation/ManagedMarkupExtension.cs
@@ -124,7 +124,7 @@ public abstract class ManagedMarkupExtension : MarkupExtension
         }
 
         TargetProperty = provideValueTarget!.TargetProperty;
-        TargetObjects.Add(new WeakReference(target));
+        TargetObjects.Add(new(target));
     }
 
     /// <summary>Called by <see cref="UpdateTargets"/> to update each target referenced by the extension.</summary>

--- a/src/Localisation.WPF/Localisation/ResxExtension.cs
+++ b/src/Localisation.WPF/Localisation/ResxExtension.cs
@@ -582,7 +582,7 @@ public class ResxExtension : ManagedMarkupExtension
     /// </returns>
     private static string? GetProcessFilepath(int processId)
     {
-        var wmiQueryString = "SELECT ProcessId, ExecutablePath FROM Win32_Process WHERE ProcessId = " + processId;
+        var wmiQueryString = $"SELECT ProcessId, ExecutablePath FROM Win32_Process WHERE ProcessId = {processId}";
         using var searcher = new ManagementObjectSearcher(wmiQueryString);
         using var results = searcher.Get();
         return results
@@ -643,7 +643,7 @@ public class ResxExtension : ManagedMarkupExtension
 
         var culture = cultureSplit[1];
 
-        var fileName = name + ".dll";
+        var fileName = $"{name}.dll";
 
         // look for the latest version of the satellite assembly with the given culture on the
         // assembly probing paths
@@ -906,7 +906,7 @@ public class ResxExtension : ManagedMarkupExtension
         {
             if (targetType == typeof(string) || targetType == typeof(object) || IsMultiBindingChild)
             {
-                result = "#" + key;
+                result = $"#{key}";
             }
         }
         else if (targetType is not null && targetType != typeof(string) && targetType != typeof(object))
@@ -960,7 +960,7 @@ public class ResxExtension : ManagedMarkupExtension
                 result = new(resxName, assembly);
             }
 
-            _resourceManagers.Add(resxName, new WeakReference(result));
+            _resourceManagers.Add(resxName, new(result));
         }
 
         return result;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature and build/test compatibility maintenance.

## What is the new behavior?

- Adds `net472`, `net48`, and `net481` support to the WPF packages.
- Applies preserialized resource handling and `System.Resources.Extensions` to every `net4*` target.
- Updates ReactiveUI.Primitives, StyleSharp, TUnit, and cryptography dependencies.
- Resolves compiler/analyzer diagnostics without suppressions.
- Retargets the WPF test application to `net10.0-windows`.
- Runs the BuildOnly workflow from non-main branch pushes instead of a separate `pull_request` trigger.

## What is the current behavior?

The WPF packages target `net462` and modern Windows TFMs, resource support is configured only for `net462`, and the dependency upgrades expose analyzer/build failures that prevent a clean full solution build.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation completed locally:

- `dotnet build src\Localisation.slnx --configuration Release --no-incremental -m:1 -v:minimal`
- Build result: 0 warnings, 0 errors.
- Microsoft.Testing.Platform/TUnit result: 18/18 passed (Avalonia 10/10; WPF 8/8).
- Merged coverage: 55.34% lines and 45.74% branches.

The BuildOnly workflow is now push-only. Same-repository PR head commits are validated by branch pushes, while fork PR merge refs will not run this workflow.
